### PR TITLE
fix: record controller now updates event data within a session, instead of creating new session ID with every targetApp post request

### DIFF
--- a/backend/controllers/record.js
+++ b/backend/controllers/record.js
@@ -19,7 +19,7 @@ const userMetadata = {
   location: null,
 };
 
-recordRouter.post("/", (req, res) => {
+recordRouter.post("/", async (req, res) => {
   extractMetadata(req, userMetadata)
 
   const batchOfEvents = req.body;
@@ -27,11 +27,11 @@ recordRouter.post("/", (req, res) => {
   allRecordedEvents.push(batchOfEvents);
 
   const allEventsCompressed = compressEvents(allRecordedEvents)
-  
+
   if (sessionIndex) {
     updateSessionEvents(allEventsCompressed, sessionIndex, res)
   } else {
-    sessionIndex = createNewSession(allEventsCompressed, userMetadata, res)
+    sessionIndex = await createNewSession(allEventsCompressed, userMetadata, res)
   }
 });
 

--- a/backend/utils/recordHelpers.js
+++ b/backend/utils/recordHelpers.js
@@ -37,12 +37,13 @@ function updateSessionEvents(allEventsCompressed, sessionIndex, res) {
 }
 
 function createNewSession(allEventsCompressed, userMetadata, res) {
-  postgres.db.one('INSERT INTO sessions(session_data, url, ip_address, city, region, country, os_name, os_version, browser_name, browser_version, https_protected, viewport_height, viewport_width) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id', 
+  return postgres.db.one('INSERT INTO sessions(session_data, url, ip_address, city, region, country, os_name, os_version, browser_name, browser_version, https_protected, viewport_height, viewport_width) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id', 
       [allEventsCompressed, "www.website.com/stuff", userMetadata.ip, "Kakariko Village", "Dueling Peaks", "Hyrule", userMetadata.os.name, userMetadata.os.version, userMetadata.browser.name, userMetadata.browser.version, true, 1280, 567], session => session.id)
     .then(data => {
         sessionIndex = data;
         res.sendStatus(200);
         console.log(`Successfully added new session to database. Current ID is ${sessionIndex}`)
+        return data;
     })
     .catch((error) => {
       console.log('Unable to add new session to PostgreSQL:', error.message);


### PR DESCRIPTION
Waits for promise to settle before assigning new session index which prevents each request from generating a new session index.